### PR TITLE
コメント機能についての修正

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -3,13 +3,15 @@ class CommentsController < ApplicationController
     @tweet = Tweet.find_by(id: params[:id])
     @comments = Comment.where(tweet_id: @tweet.id)
   end
+
   def new
   end
+
   def create
     @comment = Comment.new(user_id: current_user.id, tweet_id: params[:id], text: params[:text])
     if @comment.save
       flash[:notice] = "投稿を作成しました"
-      redirect_to("/")
+      redirect_to comment_path
     else
       render("tweets/new")
     end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,13 +1,15 @@
 class TweetsController < ApplicationController
   def new
   end
+
   def create
-    @tweet = Tweet.new(user_id: current_user.id, text: params[:text])
+    @tweet = current_user.tweets.build(user_id: current_user.id, text: params[:text])
     if @tweet.save
       flash[:notice] = "投稿を作成しました"
-      redirect_to("/")
+      redirect_to root_path
     else
       render("tweets/new")
     end
   end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,13 @@
 class UsersController < ApplicationController
+ 
   def withdrawal
     current_user.update(is_deleted: true)
     reset_session
     flash[:notice] = "退会処理を実行いたしました"
-    redirect_to '/'
+    redirect_to root_path
   end
 
   def show
   end
+
 end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,4 +2,5 @@ class Tweet < ApplicationRecord
   validates :text, {presence: true, length:{maximum:140}}
 
   belongs_to :user
+  has_many :comment
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,6 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :tweets
 end

--- a/app/views/comments/new.html.slim
+++ b/app/views/comments/new.html.slim
@@ -4,7 +4,7 @@ header
 
 .main 
   .main-format 
-    = form_with url: comments_create_path do |f|
+    = form_with url: "/comments/#{params[:id]}/create" do |f|
       .tweet-form
         .tweet-form-body
           = f.text_area :text 

--- a/app/views/home/top.html.slim
+++ b/app/views/home/top.html.slim
@@ -17,7 +17,7 @@ header
         .post-right 
           .post-user-name 
             = tweet.user.name
-          = link_to  tweet.text,"/comments/#{tweet.id}/show"
+          = link_to  tweet.text, "comments/#{tweet.id}"
 
   -if current_user
     .tweet-menu
@@ -26,7 +26,7 @@ header
       .tweet-user-name
         = link_to current_user.name, "/users/#{current_user.id}"
       .tweet-do 
-        = link_to 'つぶやく', tweets_new_path 
+        = link_to 'つぶやく', new_tweet_path
     
   - else
    .login-form

--- a/app/views/tweets/new.html.slim
+++ b/app/views/tweets/new.html.slim
@@ -4,7 +4,7 @@ header
 
 .main 
   .main-format 
-    = form_with url: tweets_create_path do |f|
+    = form_with url: tweets_path do |f|
       .tweet-form
         .tweet-form-body
           = f.text_area :text 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,12 @@
 Rails.application.routes.draw do
-  get 'comments/:id/show' => 'comments#show'
   get 'comments/:id/new' => 'comments#new'
-  post 'comments/create' => 'comments#create'
+  post 'comments/:id/create' => 'comments#create'
 
   devise_for :users
-  get '/' => 'home#top'
+  get '/' => 'home#top', as: 'root'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   patch '/users/:id/withdrawal' => 'users#withdrawal', as: 'withdrawal'
-  get 'tweets/new' => 'tweets#new'
-  post 'tweets/create' => 'tweets#create'
 
   resources :users, only: %i[show]
+  resources :tweets, :comments
 end

--- a/db/migrate/20221129174002_add_reference_to_tweet.rb
+++ b/db/migrate/20221129174002_add_reference_to_tweet.rb
@@ -1,0 +1,5 @@
+class AddReferenceToTweet < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :tweets, :user_id, :string
+  end
+end

--- a/db/migrate/20221129180906_add_user_id_to_tweet.rb
+++ b/db/migrate/20221129180906_add_user_id_to_tweet.rb
@@ -1,0 +1,5 @@
+class AddUserIdToTweet < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :tweets, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20221129181119_remove_tweet_and_user_id_to_comment.rb
+++ b/db/migrate/20221129181119_remove_tweet_and_user_id_to_comment.rb
@@ -1,0 +1,6 @@
+class RemoveTweetAndUserIdToComment < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :comments, :user_id, :string
+    remove_column :comments, :tweet_id, :string
+  end
+end

--- a/db/migrate/20221129181239_add_reference_tweet_and_user_id_to_comment.rb
+++ b/db/migrate/20221129181239_add_reference_tweet_and_user_id_to_comment.rb
@@ -1,0 +1,6 @@
+class AddReferenceTweetAndUserIdToComment < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :comments, :user, foreign_key: true
+    add_reference :comments, :tweet, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,21 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_28_074224) do
+ActiveRecord::Schema.define(version: 2022_11_29_181239) do
 
   create_table "comments", force: :cascade do |t|
-    t.string "user_id", null: false
-    t.string "tweet_id", null: false
     t.text "text", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id"
+    t.integer "tweet_id"
+    t.index ["tweet_id"], name: "index_comments_on_tweet_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "tweets", force: :cascade do |t|
-    t.string "user_id", null: false
     t.text "text", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_tweets_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -43,4 +46,7 @@ ActiveRecord::Schema.define(version: 2022_11_28_074224) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "comments", "tweets"
+  add_foreign_key "comments", "users"
+  add_foreign_key "tweets", "users"
 end


### PR DESCRIPTION
・コントローラの行間開け
・ルーティングをresourceに変更
留意点："/comments/:id/create"と"/comments/:id/new"はresoureでヘルパーできなかったので残してあります。
・redirect_to の後をヘルパーに変更
・userとtweetのアソシエーション追加
・コメントモデルとツイートモデルのカラムに外部キー付与

一旦作業したものをローカルでmasterにマージして、ブランチを切ってアップしました。
比較対象としてわかりやすいようにrails-taskと比べていますがあっていますでしょうか？
よろしくお願いいたします！